### PR TITLE
Add botanical brand artwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/brand/banner-dark.svg" />
+  <img alt="Open Trees warm paper banner" src="docs/assets/brand/banner-light.svg" width="100%" />
+</picture>
+
 # Open Trees
 
 OpenCode plugin for fast, safe `git worktree` workflows.
@@ -183,6 +188,15 @@ npm audit --omit=dev
 ## Versioning
 
 Open Trees follows Semantic Versioning and tracks notable changes in `CHANGELOG.md`.
+
+## Brand
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/brand/release-dark.svg" />
+  <img alt="Open Trees release card" src="docs/assets/brand/release-light.svg" width="100%" />
+</picture>
+
+Brand visuals, SVG assets, and usage guidelines live in `docs/brand.md`.
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,8 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/brand/banner-dark.svg" />
+  <img alt="Open Trees warm paper banner" src="assets/brand/banner-light.svg" width="100%" />
+</picture>
+
 # Open Trees
 
 OpenCode plugin for fast, safe `git worktree` workflow management.
@@ -77,3 +82,7 @@ worktree_make { "action": "create", "name": "feature auth" }
 # Start a session in the worktree
 worktree_make { "action": "start", "name": "feature auth", "openSessions": true }
 ```
+
+## Brand
+
+Warm paper visuals and SVG assets live in `docs/brand.md`.

--- a/docs/assets/brand/banner-dark.svg
+++ b/docs/assets/brand/banner-dark.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="420" viewBox="0 0 1200 420" role="img" aria-labelledby="title desc">
+  <title id="title">Open Trees</title>
+  <desc id="desc">Warm paper banner with botanical sketch.</desc>
+  <defs>
+    <linearGradient id="paper" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="hsl(30, 5%, 10.5%)" />
+      <stop offset="100%" stop-color="hsl(30, 5%, 12%)" />
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="hsl(30, 5%, 13%)" />
+      <stop offset="100%" stop-color="hsl(30, 5%, 11.5%)" />
+    </linearGradient>
+    <pattern id="grain" width="28" height="28" patternUnits="userSpaceOnUse">
+      <circle cx="6" cy="6" r="1" fill="hsl(35, 8%, 24%)" opacity="0.6" />
+      <circle cx="18" cy="12" r="1.2" fill="hsl(35, 8%, 24%)" opacity="0.5" />
+      <circle cx="10" cy="22" r="0.9" fill="hsl(35, 8%, 24%)" opacity="0.45" />
+    </pattern>
+    <path id="leaf-shape" d="M0 0 C 14 -22 46 -22 60 0 C 46 22 14 22 0 0 Z" />
+    <path id="leaf-vein" d="M8 0 C 22 -2 38 -2 52 0" />
+    <g id="leaf-outline">
+      <use href="#leaf-shape" />
+      <use href="#leaf-vein" />
+    </g>
+    <clipPath id="card-clip" clipPathUnits="userSpaceOnUse">
+      <rect x="70" y="70" width="660" height="280" rx="24" />
+    </clipPath>
+  </defs>
+  <rect width="1200" height="420" fill="url(#paper)" />
+  <rect width="1200" height="420" fill="url(#grain)" opacity="0.55" />
+  <rect x="70" y="70" width="660" height="280" rx="24" fill="url(#card)" stroke="hsl(30, 5%, 20%)" />
+  <g clip-path="url(#card-clip)">
+    <use href="#leaf-shape" transform="translate(150 210) rotate(-6) scale(5.2)" fill="hsl(35, 12%, 20%)" opacity="0.35" />
+    <path d="M120 260 C210 210 330 240 450 210 C530 190 610 190 680 170" stroke="hsl(30, 5%, 20%)" stroke-width="2" opacity="0.7" fill="none" />
+    <g fill="none" stroke="hsl(35, 15%, 70%)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.85">
+      <use href="#leaf-outline" transform="translate(140 240) rotate(-18) scale(0.7)" />
+      <use href="#leaf-outline" transform="translate(210 220) rotate(12) scale(0.65)" />
+      <use href="#leaf-outline" transform="translate(300 238) rotate(-12) scale(0.6)" />
+      <use href="#leaf-outline" transform="translate(400 214) rotate(18) scale(0.7)" />
+      <use href="#leaf-outline" transform="translate(500 198) rotate(-6) scale(0.6)" />
+      <use href="#leaf-outline" transform="translate(590 188) rotate(14) scale(0.55)" />
+    </g>
+    <g fill="hsl(35, 12%, 20%)" opacity="0.7">
+      <circle cx="170" cy="150" r="3" />
+      <circle cx="240" cy="170" r="2" />
+      <circle cx="520" cy="140" r="2.5" />
+      <circle cx="620" cy="150" r="3" />
+    </g>
+  </g>
+  <g stroke="hsl(35, 15%, 70%)" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <g stroke-width="3" opacity="0.85">
+      <path d="M980 350 C940 310 920 260 930 210 C940 160 990 120 1060 80" />
+      <path d="M940 260 C900 240 860 240 820 250" />
+      <path d="M960 220 C990 210 1020 200 1050 200" />
+    </g>
+    <g stroke-width="2" opacity="0.9">
+      <use href="#leaf-outline" transform="translate(900 150) rotate(-18) scale(0.75)" />
+      <use href="#leaf-outline" transform="translate(950 120) rotate(8) scale(0.8)" />
+      <use href="#leaf-outline" transform="translate(1015 120) rotate(22) scale(0.72)" />
+      <use href="#leaf-outline" transform="translate(975 200) rotate(-6) scale(0.85)" />
+      <use href="#leaf-outline" transform="translate(860 232) rotate(-30) scale(0.62)" />
+      <use href="#leaf-outline" transform="translate(835 260) rotate(12) scale(0.52)" />
+      <use href="#leaf-outline" transform="translate(930 300) rotate(18) scale(0.7)" />
+      <use href="#leaf-outline" transform="translate(1020 280) rotate(-12) scale(0.6)" />
+      <use href="#leaf-outline" transform="translate(1055 235) rotate(35) scale(0.55)" />
+    </g>
+  </g>
+</svg>

--- a/docs/assets/brand/banner-light.svg
+++ b/docs/assets/brand/banner-light.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="420" viewBox="0 0 1200 420" role="img" aria-labelledby="title desc">
+  <title id="title">Open Trees</title>
+  <desc id="desc">Warm paper banner with botanical sketch.</desc>
+  <defs>
+    <linearGradient id="paper" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="hsl(40, 30%, 97%)" />
+      <stop offset="100%" stop-color="hsl(38, 28%, 95%)" />
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="hsl(40, 25%, 96%)" />
+      <stop offset="100%" stop-color="hsl(40, 25%, 94%)" />
+    </linearGradient>
+    <pattern id="grain" width="28" height="28" patternUnits="userSpaceOnUse">
+      <circle cx="6" cy="6" r="1" fill="hsl(35, 20%, 88%)" opacity="0.5" />
+      <circle cx="18" cy="12" r="1.2" fill="hsl(35, 20%, 88%)" opacity="0.45" />
+      <circle cx="10" cy="22" r="0.9" fill="hsl(35, 20%, 88%)" opacity="0.4" />
+    </pattern>
+    <path id="leaf-shape" d="M0 0 C 14 -22 46 -22 60 0 C 46 22 14 22 0 0 Z" />
+    <path id="leaf-vein" d="M8 0 C 22 -2 38 -2 52 0" />
+    <g id="leaf-outline">
+      <use href="#leaf-shape" />
+      <use href="#leaf-vein" />
+    </g>
+    <clipPath id="card-clip" clipPathUnits="userSpaceOnUse">
+      <rect x="70" y="70" width="660" height="280" rx="24" />
+    </clipPath>
+  </defs>
+  <rect width="1200" height="420" fill="url(#paper)" />
+  <rect width="1200" height="420" fill="url(#grain)" opacity="0.5" />
+  <rect x="70" y="70" width="660" height="280" rx="24" fill="url(#card)" stroke="hsl(35, 15%, 85%)" />
+  <g clip-path="url(#card-clip)">
+    <use href="#leaf-shape" transform="translate(150 210) rotate(-6) scale(5.2)" fill="hsl(35, 20%, 88%)" opacity="0.28" />
+    <path d="M120 260 C210 210 330 240 450 210 C530 190 610 190 680 170" stroke="hsl(35, 15%, 85%)" stroke-width="2" opacity="0.7" fill="none" />
+    <g fill="none" stroke="hsl(30, 18%, 35%)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.85">
+      <use href="#leaf-outline" transform="translate(140 240) rotate(-18) scale(0.7)" />
+      <use href="#leaf-outline" transform="translate(210 220) rotate(12) scale(0.65)" />
+      <use href="#leaf-outline" transform="translate(300 238) rotate(-12) scale(0.6)" />
+      <use href="#leaf-outline" transform="translate(400 214) rotate(18) scale(0.7)" />
+      <use href="#leaf-outline" transform="translate(500 198) rotate(-6) scale(0.6)" />
+      <use href="#leaf-outline" transform="translate(590 188) rotate(14) scale(0.55)" />
+    </g>
+    <g fill="hsl(35, 20%, 88%)" opacity="0.7">
+      <circle cx="170" cy="150" r="3" />
+      <circle cx="240" cy="170" r="2" />
+      <circle cx="520" cy="140" r="2.5" />
+      <circle cx="620" cy="150" r="3" />
+    </g>
+  </g>
+  <g stroke="hsl(30, 18%, 35%)" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <g stroke-width="3" opacity="0.8">
+      <path d="M980 350 C940 310 920 260 930 210 C940 160 990 120 1060 80" />
+      <path d="M940 260 C900 240 860 240 820 250" />
+      <path d="M960 220 C990 210 1020 200 1050 200" />
+    </g>
+    <g stroke-width="2" opacity="0.9">
+      <use href="#leaf-outline" transform="translate(900 150) rotate(-18) scale(0.75)" />
+      <use href="#leaf-outline" transform="translate(950 120) rotate(8) scale(0.8)" />
+      <use href="#leaf-outline" transform="translate(1015 120) rotate(22) scale(0.72)" />
+      <use href="#leaf-outline" transform="translate(975 200) rotate(-6) scale(0.85)" />
+      <use href="#leaf-outline" transform="translate(860 232) rotate(-30) scale(0.62)" />
+      <use href="#leaf-outline" transform="translate(835 260) rotate(12) scale(0.52)" />
+      <use href="#leaf-outline" transform="translate(930 300) rotate(18) scale(0.7)" />
+      <use href="#leaf-outline" transform="translate(1020 280) rotate(-12) scale(0.6)" />
+      <use href="#leaf-outline" transform="translate(1055 235) rotate(35) scale(0.55)" />
+    </g>
+  </g>
+</svg>

--- a/docs/assets/brand/pattern-dark.svg
+++ b/docs/assets/brand/pattern-dark.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="160" viewBox="0 0 1200 160" role="img" aria-labelledby="title desc">
+  <title id="title">Warm paper botanical pattern</title>
+  <desc id="desc">Subtle botanical line art for documentation headers.</desc>
+  <defs>
+    <linearGradient id="wash" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="hsl(30, 5%, 10.5%)" />
+      <stop offset="100%" stop-color="hsl(30, 5%, 12%)" />
+    </linearGradient>
+    <pattern id="grain" width="26" height="26" patternUnits="userSpaceOnUse">
+      <circle cx="6" cy="6" r="1" fill="hsl(35, 8%, 24%)" opacity="0.55" />
+      <circle cx="16" cy="14" r="1.1" fill="hsl(35, 8%, 24%)" opacity="0.5" />
+    </pattern>
+    <g id="leaf">
+      <path d="M0 0 C 10 -16 34 -16 44 0 C 34 16 10 16 0 0 Z" />
+      <path d="M6 0 C 16 -2 28 -2 38 0" />
+    </g>
+  </defs>
+  <rect width="1200" height="160" fill="url(#wash)" />
+  <rect width="1200" height="160" fill="url(#grain)" opacity="0.6" />
+  <g stroke="hsl(35, 15%, 70%)" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M0 115 C220 70 420 140 600 95 C820 50 980 140 1200 85" stroke-width="2" opacity="0.55" />
+    <use href="#leaf" transform="translate(120 92) rotate(-10) scale(0.55)" />
+    <use href="#leaf" transform="translate(260 86) rotate(12) scale(0.6)" />
+    <use href="#leaf" transform="translate(430 104) rotate(-14) scale(0.5)" />
+    <use href="#leaf" transform="translate(610 86) rotate(18) scale(0.6)" />
+    <use href="#leaf" transform="translate(780 98) rotate(-18) scale(0.55)" />
+    <use href="#leaf" transform="translate(980 84) rotate(14) scale(0.6)" />
+  </g>
+</svg>

--- a/docs/assets/brand/pattern-light.svg
+++ b/docs/assets/brand/pattern-light.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="160" viewBox="0 0 1200 160" role="img" aria-labelledby="title desc">
+  <title id="title">Warm paper botanical pattern</title>
+  <desc id="desc">Subtle botanical line art for documentation headers.</desc>
+  <defs>
+    <linearGradient id="wash" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="hsl(40, 30%, 97%)" />
+      <stop offset="100%" stop-color="hsl(38, 25%, 95%)" />
+    </linearGradient>
+    <pattern id="grain" width="26" height="26" patternUnits="userSpaceOnUse">
+      <circle cx="6" cy="6" r="1" fill="hsl(35, 20%, 88%)" opacity="0.45" />
+      <circle cx="16" cy="14" r="1.1" fill="hsl(35, 20%, 88%)" opacity="0.4" />
+    </pattern>
+    <g id="leaf">
+      <path d="M0 0 C 10 -16 34 -16 44 0 C 34 16 10 16 0 0 Z" />
+      <path d="M6 0 C 16 -2 28 -2 38 0" />
+    </g>
+  </defs>
+  <rect width="1200" height="160" fill="url(#wash)" />
+  <rect width="1200" height="160" fill="url(#grain)" opacity="0.6" />
+  <g stroke="hsl(30, 18%, 35%)" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M0 115 C220 70 420 140 600 95 C820 50 980 140 1200 85" stroke-width="2" opacity="0.5" />
+    <use href="#leaf" transform="translate(120 92) rotate(-10) scale(0.55)" />
+    <use href="#leaf" transform="translate(260 86) rotate(12) scale(0.6)" />
+    <use href="#leaf" transform="translate(430 104) rotate(-14) scale(0.5)" />
+    <use href="#leaf" transform="translate(610 86) rotate(18) scale(0.6)" />
+    <use href="#leaf" transform="translate(780 98) rotate(-18) scale(0.55)" />
+    <use href="#leaf" transform="translate(980 84) rotate(14) scale(0.6)" />
+  </g>
+</svg>

--- a/docs/assets/brand/release-dark.svg
+++ b/docs/assets/brand/release-dark.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Open Trees release</title>
+  <desc id="desc">Warm paper release card with botanical sketch.</desc>
+  <defs>
+    <linearGradient id="paper" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="hsl(30, 5%, 10.5%)" />
+      <stop offset="100%" stop-color="hsl(30, 5%, 12%)" />
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="hsl(30, 5%, 13%)" />
+      <stop offset="100%" stop-color="hsl(30, 5%, 11.5%)" />
+    </linearGradient>
+    <pattern id="grain" width="28" height="28" patternUnits="userSpaceOnUse">
+      <circle cx="6" cy="6" r="1" fill="hsl(35, 8%, 24%)" opacity="0.6" />
+      <circle cx="18" cy="12" r="1.2" fill="hsl(35, 8%, 24%)" opacity="0.5" />
+      <circle cx="10" cy="22" r="0.9" fill="hsl(35, 8%, 24%)" opacity="0.45" />
+    </pattern>
+    <path id="leaf-shape" d="M0 0 C 14 -22 46 -22 60 0 C 46 22 14 22 0 0 Z" />
+    <path id="leaf-vein" d="M8 0 C 22 -2 38 -2 52 0" />
+    <g id="leaf-outline">
+      <use href="#leaf-shape" />
+      <use href="#leaf-vein" />
+    </g>
+    <clipPath id="card-clip" clipPathUnits="userSpaceOnUse">
+      <rect x="70" y="80" width="720" height="470" rx="28" />
+    </clipPath>
+  </defs>
+  <rect width="1200" height="630" fill="url(#paper)" />
+  <rect width="1200" height="630" fill="url(#grain)" opacity="0.55" />
+  <rect x="70" y="80" width="720" height="470" rx="28" fill="url(#card)" stroke="hsl(30, 5%, 20%)" />
+  <g clip-path="url(#card-clip)">
+    <use href="#leaf-shape" transform="translate(140 300) rotate(-8) scale(6.2)" fill="hsl(35, 12%, 20%)" opacity="0.32" />
+    <circle cx="590" cy="220" r="70" fill="none" stroke="hsl(30, 5%, 20%)" stroke-width="2" opacity="0.8" />
+    <circle cx="590" cy="220" r="52" fill="none" stroke="hsl(30, 5%, 20%)" stroke-width="1.5" opacity="0.7" />
+    <path d="M130 420 C220 360 360 390 500 350 C600 320 700 320 760 280" stroke="hsl(30, 5%, 20%)" stroke-width="2" opacity="0.7" fill="none" />
+    <g fill="none" stroke="hsl(35, 15%, 70%)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.85">
+      <use href="#leaf-outline" transform="translate(150 400) rotate(-18) scale(0.85)" />
+      <use href="#leaf-outline" transform="translate(250 372) rotate(10) scale(0.8)" />
+      <use href="#leaf-outline" transform="translate(360 392) rotate(-12) scale(0.75)" />
+      <use href="#leaf-outline" transform="translate(470 360) rotate(18) scale(0.85)" />
+      <use href="#leaf-outline" transform="translate(600 340) rotate(-8) scale(0.7)" />
+      <use href="#leaf-outline" transform="translate(700 320) rotate(14) scale(0.65)" />
+    </g>
+    <g fill="hsl(35, 12%, 20%)" opacity="0.7">
+      <circle cx="190" cy="210" r="3" />
+      <circle cx="260" cy="240" r="2" />
+      <circle cx="480" cy="210" r="2.5" />
+      <circle cx="650" cy="250" r="3" />
+    </g>
+  </g>
+  <g stroke="hsl(35, 15%, 70%)" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <g stroke-width="3" opacity="0.85">
+      <path d="M980 520 C940 480 920 420 930 360 C940 300 1000 240 1080 180" />
+      <path d="M940 430 C900 400 860 392 820 395" />
+      <path d="M990 350 C1040 330 1080 310 1120 290" />
+    </g>
+    <g stroke-width="2" opacity="0.9">
+      <use href="#leaf-outline" transform="translate(900 300) rotate(-18) scale(0.95)" />
+      <use href="#leaf-outline" transform="translate(970 248) rotate(10) scale(1)" />
+      <use href="#leaf-outline" transform="translate(1040 230) rotate(24) scale(0.85)" />
+      <use href="#leaf-outline" transform="translate(1010 340) rotate(-8) scale(0.9)" />
+      <use href="#leaf-outline" transform="translate(860 400) rotate(-28) scale(0.8)" />
+      <use href="#leaf-outline" transform="translate(835 432) rotate(14) scale(0.65)" />
+      <use href="#leaf-outline" transform="translate(980 470) rotate(18) scale(0.9)" />
+      <use href="#leaf-outline" transform="translate(1070 440) rotate(-12) scale(0.75)" />
+      <use href="#leaf-outline" transform="translate(1100 360) rotate(30) scale(0.7)" />
+    </g>
+  </g>
+</svg>

--- a/docs/assets/brand/release-light.svg
+++ b/docs/assets/brand/release-light.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Open Trees release</title>
+  <desc id="desc">Warm paper release card with botanical sketch.</desc>
+  <defs>
+    <linearGradient id="paper" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="hsl(40, 30%, 97%)" />
+      <stop offset="100%" stop-color="hsl(38, 28%, 95%)" />
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="hsl(40, 25%, 96%)" />
+      <stop offset="100%" stop-color="hsl(40, 25%, 94%)" />
+    </linearGradient>
+    <pattern id="grain" width="28" height="28" patternUnits="userSpaceOnUse">
+      <circle cx="6" cy="6" r="1" fill="hsl(35, 20%, 88%)" opacity="0.5" />
+      <circle cx="18" cy="12" r="1.2" fill="hsl(35, 20%, 88%)" opacity="0.45" />
+      <circle cx="10" cy="22" r="0.9" fill="hsl(35, 20%, 88%)" opacity="0.4" />
+    </pattern>
+    <path id="leaf-shape" d="M0 0 C 14 -22 46 -22 60 0 C 46 22 14 22 0 0 Z" />
+    <path id="leaf-vein" d="M8 0 C 22 -2 38 -2 52 0" />
+    <g id="leaf-outline">
+      <use href="#leaf-shape" />
+      <use href="#leaf-vein" />
+    </g>
+    <clipPath id="card-clip" clipPathUnits="userSpaceOnUse">
+      <rect x="70" y="80" width="720" height="470" rx="28" />
+    </clipPath>
+  </defs>
+  <rect width="1200" height="630" fill="url(#paper)" />
+  <rect width="1200" height="630" fill="url(#grain)" opacity="0.5" />
+  <rect x="70" y="80" width="720" height="470" rx="28" fill="url(#card)" stroke="hsl(35, 15%, 85%)" />
+  <g clip-path="url(#card-clip)">
+    <use href="#leaf-shape" transform="translate(140 300) rotate(-8) scale(6.2)" fill="hsl(35, 20%, 88%)" opacity="0.22" />
+    <circle cx="590" cy="220" r="70" fill="none" stroke="hsl(35, 15%, 85%)" stroke-width="2" opacity="0.8" />
+    <circle cx="590" cy="220" r="52" fill="none" stroke="hsl(35, 15%, 85%)" stroke-width="1.5" opacity="0.7" />
+    <path d="M130 420 C220 360 360 390 500 350 C600 320 700 320 760 280" stroke="hsl(35, 15%, 85%)" stroke-width="2" opacity="0.7" fill="none" />
+    <g fill="none" stroke="hsl(30, 18%, 35%)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.85">
+      <use href="#leaf-outline" transform="translate(150 400) rotate(-18) scale(0.85)" />
+      <use href="#leaf-outline" transform="translate(250 372) rotate(10) scale(0.8)" />
+      <use href="#leaf-outline" transform="translate(360 392) rotate(-12) scale(0.75)" />
+      <use href="#leaf-outline" transform="translate(470 360) rotate(18) scale(0.85)" />
+      <use href="#leaf-outline" transform="translate(600 340) rotate(-8) scale(0.7)" />
+      <use href="#leaf-outline" transform="translate(700 320) rotate(14) scale(0.65)" />
+    </g>
+    <g fill="hsl(35, 20%, 88%)" opacity="0.7">
+      <circle cx="190" cy="210" r="3" />
+      <circle cx="260" cy="240" r="2" />
+      <circle cx="480" cy="210" r="2.5" />
+      <circle cx="650" cy="250" r="3" />
+    </g>
+  </g>
+  <g stroke="hsl(30, 18%, 35%)" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <g stroke-width="3" opacity="0.8">
+      <path d="M980 520 C940 480 920 420 930 360 C940 300 1000 240 1080 180" />
+      <path d="M940 430 C900 400 860 392 820 395" />
+      <path d="M990 350 C1040 330 1080 310 1120 290" />
+    </g>
+    <g stroke-width="2" opacity="0.9">
+      <use href="#leaf-outline" transform="translate(900 300) rotate(-18) scale(0.95)" />
+      <use href="#leaf-outline" transform="translate(970 248) rotate(10) scale(1)" />
+      <use href="#leaf-outline" transform="translate(1040 230) rotate(24) scale(0.85)" />
+      <use href="#leaf-outline" transform="translate(1010 340) rotate(-8) scale(0.9)" />
+      <use href="#leaf-outline" transform="translate(860 400) rotate(-28) scale(0.8)" />
+      <use href="#leaf-outline" transform="translate(835 432) rotate(14) scale(0.65)" />
+      <use href="#leaf-outline" transform="translate(980 470) rotate(18) scale(0.9)" />
+      <use href="#leaf-outline" transform="translate(1070 440) rotate(-12) scale(0.75)" />
+      <use href="#leaf-outline" transform="translate(1100 360) rotate(30) scale(0.7)" />
+    </g>
+  </g>
+</svg>

--- a/docs/brand.md
+++ b/docs/brand.md
@@ -1,0 +1,68 @@
+# Brand
+
+Open Trees uses a warm paper design system with subtle texture, soft borders, and botanical sketch line art.
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/brand/banner-dark.svg" />
+  <img alt="Open Trees banner" src="assets/brand/banner-light.svg" width="100%" />
+</picture>
+
+## Assets
+
+- Banners: `docs/assets/brand/banner-light.svg`, `docs/assets/brand/banner-dark.svg`
+- Release cards: `docs/assets/brand/release-light.svg`, `docs/assets/brand/release-dark.svg`
+- Pattern strip: `docs/assets/brand/pattern-light.svg`, `docs/assets/brand/pattern-dark.svg`
+- Release notes template: `docs/release-notes.md`
+
+## Color tokens
+
+| Token | Light | Dark |
+| --- | --- | --- |
+| `paper` | hsl(40, 30%, 97%) | hsl(30, 5%, 10.5%) |
+| `surface` | hsl(40, 25%, 95%) | hsl(30, 5%, 12%) |
+| `text` | hsl(30, 15%, 15%) | hsl(40, 20%, 92%) |
+| `border` | hsl(35, 15%, 85%) | hsl(30, 5%, 20%) |
+| `accent` | hsl(35, 20%, 88%) | hsl(35, 12%, 20%) |
+| `ring` | hsl(30, 20%, 25%) | hsl(35, 15%, 70%) |
+
+## Typography
+
+- Primary: Geist Sans
+- Code: Geist Mono
+- Titles: text-2xl, font-semibold, tracking-tight
+- Body: text-sm
+
+## Interaction cues
+
+- Focus ring: 2px with 2px offset using the `ring` token
+- Hover: subtle accent background with smooth transition-colors
+- Disabled: 50% opacity
+
+## Usage
+
+README banner:
+
+```html
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/brand/banner-dark.svg" />
+  <img alt="Open Trees warm paper banner" src="docs/assets/brand/banner-light.svg" width="100%" />
+</picture>
+```
+
+Docs header strip:
+
+```html
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/brand/pattern-dark.svg" />
+  <img alt="Warm paper pattern" src="assets/brand/pattern-light.svg" width="100%" />
+</picture>
+```
+
+Release card:
+
+```html
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/0xSero/open-trees/main/docs/assets/brand/release-dark.svg" />
+  <img alt="Open Trees release card" src="https://raw.githubusercontent.com/0xSero/open-trees/main/docs/assets/brand/release-light.svg" width="100%" />
+</picture>
+```

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -1,3 +1,8 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/brand/pattern-dark.svg" />
+  <img alt="Warm paper pattern" src="assets/brand/pattern-light.svg" width="100%" />
+</picture>
+
 # File Structure
 
 ## Source Directory (`src/`)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,3 +1,8 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/brand/pattern-dark.svg" />
+  <img alt="Warm paper pattern" src="assets/brand/pattern-light.svg" width="100%" />
+</picture>
+
 # Installation
 
 ## Prerequisites

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,14 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/0xSero/open-trees/main/docs/assets/brand/release-dark.svg" />
+  <img alt="Open Trees release card" src="https://raw.githubusercontent.com/0xSero/open-trees/main/docs/assets/brand/release-light.svg" width="100%" />
+</picture>
+
+## Highlights
+
+- Warm paper botanical visuals for README, docs, and release notes.
+- SVG assets for banners, patterns, and release cards.
+- Documented brand tokens and usage snippets in `docs/brand.md`.
+
+## Details
+
+See `CHANGELOG.md` for the full release history.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,3 +1,8 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/brand/pattern-dark.svg" />
+  <img alt="Warm paper pattern" src="assets/brand/pattern-light.svg" width="100%" />
+</picture>
+
 # Usage Guide
 
 ## Enable Worktree Mode


### PR DESCRIPTION
## Summary\n- Replace brand SVGs with botanical art-only versions.\n- Keep warm paper texture and line-art motifs across banners, patterns, and release card.\n- Embed the release card preview in README and keep docs header art.\n\n## Testing\n- Not run (visual/docs-only changes).